### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -3,6 +3,9 @@ run-name: Verify package version
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   # cancel any running action on new push
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
Potential fix for [https://github.com/A-star-logic/config-typescript/security/code-scanning/1](https://github.com/A-star-logic/config-typescript/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/verify.yml` so the workflow does not rely on repository/org defaults for `GITHUB_TOKEN`.  
The least-privilege, functionality-preserving fix here is to set workflow-level permissions to:

- `contents: read`

This is sufficient for `actions/checkout@v4` and does not grant unnecessary write scopes.  
Edit location: near the top-level keys, immediately after `on:` (or before `jobs:`) in `.github/workflows/verify.yml`.  
No imports, methods, or external dependencies are required (YAML-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
