### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,8 @@
 run-name: Publish to NpmJS
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/A-star-logic/config-typescript/security/code-scanning/2](https://github.com/A-star-logic/config-typescript/security/code-scanning/2)

Add an explicit `permissions` block to `.github/workflows/publish.yml` so the workflow does not rely on external defaults.  
Best minimal fix without changing behavior: add workflow-level permissions with `contents: read`, which satisfies checkout and keeps token scope least-privilege for all jobs unless overridden.

Change location:
- File: `.github/workflows/publish.yml`
- Region: near top-level keys, after `run-name` (or before `jobs`)
- Add:
  - `permissions:`
  - `contents: read`

No imports, methods, or additional definitions are needed (YAML workflow edit only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
